### PR TITLE
Fix trackUsage return type

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -35,7 +35,7 @@ interface AuthContextType {
   ) => Promise<{ success: boolean; error: string | null }>;
   trackUsage: () => Promise<{
     success: boolean;
-    remainingFiles: number;
+    remainingOptimizations: number;
     error?: string;
   }>;
   refreshProfile: () => Promise<void>;


### PR DESCRIPTION
## Summary
- fix return type of `trackUsage` in `AuthContext`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: no test script)*
- `cd backend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc27fcac8329bfdab429c546445a